### PR TITLE
Run `git init` and `git add` automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ For a copy of the License, see [LICENSE](LICENSE).
 ### Additional license files
 
 This project may include additional license files other than the
-Apache License. Those are just there for the template user’s
-convenience so they can choose a license for their own content.
-Those licenses may not apply to this project. The only license
-that applies to this project is the Apache License.
+Apache License. Those are part of the template, which means they may
+not apply to this project. The only license that applies to this
+project is the Apache License.

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -8,28 +8,44 @@ shutil.rmtree('extension/examples')
 shutil.rmtree('extension/share')
 {%- endif %}
 
+git_commands = [
+    'git init',
+    'git add .',
+    {%- if cookiecutter.contribute_language == "y" %}
+    'git reset extension/examples extension/share',
+    'git add -N extension/examples extension/share',
+    {%- endif %}
+    'git reset extension/README.md',
+    'git add -N extension/README.md',
+]
+
+for git_command in git_commands:
+    subprocess.run(git_command, check=True, shell=True)
+
 {%- if cookiecutter.install_dependencies_now == "y" %}
 def print_formatted(message: str) -> None:
     width = max((len(line) for line in message))
     print('', width * '-', *message, width * '-', sep='\n')
 
-commands = [
+install_commands = [
     'yarn set version stable',
     'yarn plugin import https://mskelton.dev/yarn-outdated/v3',
     'yarn install',
+    'yarn clean-install',
+    'git add .yarn .yarnrc.yml package.json yarn.lock',
 ]
 
 try:
-    for command in commands:
-        subprocess.run(command, check=True, shell=True)
+    for install_command in install_commands:
+        subprocess.run(install_command, check=True, shell=True)
 except subprocess.CalledProcessError as e:
     print_formatted([
-        f'Yarn failed with exit code {e.returncode}.',
+        f'Shell command failed with exit code {e.returncode}.',
         'Go to the {{ cookiecutter.project_slug }}'
             ' directory and re-run:',
         *[
             f'    {command}'
-            for command in ['nvm use'] + commands
+            for command in ['nvm use'] + install_commands
         ],
     ])
 {%- endif %}

--- a/{{ cookiecutter.project_slug }}/.yarn/releases/LICENSE
+++ b/{{ cookiecutter.project_slug }}/.yarn/releases/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2016-present, Yarn Contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/{{ cookiecutter.project_slug }}/.yarn/sdks/LICENSE
+++ b/{{ cookiecutter.project_slug }}/.yarn/sdks/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2016-present, Yarn Contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
This serves three purposes:

- The user can spot unfinished files more easily by looking at which
  files are not staged yet;

- The user has less work of deciding what to put into source control
  and then manually doing it; and

- The BSD license is no longer being deleted from the .yarn/releases and
  .yarn/sdks subdirectories by the `yarn install` command.
  (Technically, it gets deleted but `yarn clean-install` undoes the
  deletion.)

Closes #2.
