### PR TITLE
Fix VS Code API version specifiers

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,7 @@
   "project_slug": "vscode-{{ cookiecutter.extension_slug }}",
   "extension_description": "",
   "extension_license": ["Apache-2.0", "Proprietary"],
-  "vscode_engine_min_version": "1.69.0",
+  "vscode_engine_min_version_tuple": "1.69",
   "contribute_language": "y",
   "first_language_display_name": "{{ cookiecutter.extension_display_name }}",
   "first_language_slug": "{{ cookiecutter.first_language_display_name.lower().replace(' ', '-').replace('_', '-') }}",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -9,13 +9,13 @@ shutil.rmtree('extension/share')
 {%- endif %}
 
 git_commands = [
-    'git init',
+    'git init -q',
     'git add .',
     {%- if cookiecutter.contribute_language == "y" %}
-    'git reset extension/examples extension/share',
+    'git reset -q extension/examples extension/share',
     'git add -N extension/examples extension/share',
     {%- endif %}
-    'git reset extension/README.md',
+    'git reset -q extension/README.md',
     'git add -N extension/README.md',
 ]
 

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -175,8 +175,8 @@ To bump the minimum supported VS Code version, follow these steps:
    Preserve the `@types/vscode@=` prefix as you change the value.
 
 3. In `extension/package.json` under the `engines` section, manually
-   update the value of the `vscode` property to the new version
-   tuple.  
+   update the value of the `vscode` property to the chosen version.
+   Since `vsce` expects a triple for that property, append a `.0`.  
    Preserve the `^` prefix as you change the value.
 
 4. Run `yarn clean-install`.

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -158,7 +158,7 @@ well with Yarn PnP in scripts.
 
 To also upgrade Yarn itself, run `yarn upgrade-all`.
 
-### Upgrading the VS Code API
+### Upgrading the VS Code API version
 
 Upgrading the version of the `@types/vscode` package should always
 be a manual step and a conscious decision. It effectively bumps the
@@ -167,15 +167,19 @@ minimum supported VS Code version that this extension supports.
 To bump the minimum supported VS Code version, follow these steps:
 
 1. In `package.json`, manually update the minimum version to a new
-   version triple (e.g. `^1.99.0`).  
-   Make sure to preserve the `^` prefix as you change the value.
+   version tuple (e.g. `=1.99`).  
+   Make sure to preserve the `=` prefix as you change the value.
 
-2. In `extension/package.json` under the `engines` section, manually
+2. In `package.json`, modify the `upgrade-package` script to update
+   the same tuple (e.g `@types/vscode@=1.99`).  
+   Preserve the `@types/vscode@=` prefix as you change the value.
+
+3. In `extension/package.json` under the `engines` section, manually
    update the value of the `vscode` property to the new version
-   triple.  
+   tuple.  
    Preserve the `^` prefix as you change the value.
 
-3. Run `yarn clean-install`.
+4. Run `yarn clean-install`.
 
 ## Handling vulnerable dependencies
 

--- a/{{ cookiecutter.project_slug }}/extension/package.json
+++ b/{{ cookiecutter.project_slug }}/extension/package.json
@@ -5,7 +5,7 @@
   "publisher": "{{ cookiecutter.marketplace_publisher_id }}",
   {%- endif %}
   "engines": {
-    "vscode": "^{{ cookiecutter.vscode_engine_min_version }}"
+    "vscode": "^{{ cookiecutter.vscode_engine_min_version_tuple }}"
   },
   "license": "SEE LICENSE IN README.md",
   "displayName": "{{ cookiecutter.extension_display_name }}",

--- a/{{ cookiecutter.project_slug }}/extension/package.json
+++ b/{{ cookiecutter.project_slug }}/extension/package.json
@@ -5,7 +5,7 @@
   "publisher": "{{ cookiecutter.marketplace_publisher_id }}",
   {%- endif %}
   "engines": {
-    "vscode": "^{{ cookiecutter.vscode_engine_min_version_tuple }}"
+    "vscode": "^{{ cookiecutter.vscode_engine_min_version_tuple }}.0"
   },
   "license": "SEE LICENSE IN README.md",
   "displayName": "{{ cookiecutter.extension_display_name }}",

--- a/{{ cookiecutter.project_slug }}/package.json
+++ b/{{ cookiecutter.project_slug }}/package.json
@@ -3,7 +3,7 @@
   "license": "SEE LICENSE IN README.md",
   "devDependencies": {
     "@types/node": "^18.7.13",
-    "@types/vscode": "^{{ cookiecutter.vscode_engine_min_version }}",
+    "@types/vscode": "={{ cookiecutter.vscode_engine_min_version_tuple }}",
     "@yarnpkg/sdks": "^2.6.3",
     "eslint": "^8.23.0",
     "typescript": "^4.8.2",
@@ -21,6 +21,7 @@
     "upgrade-all": "printf >&2 '%s\\n\\t%s\\n' 'Run the following command line manually:' 'yarn set version stable && yarn install && yarn upgrade-packages' && false",
     "upgrade-lockfile": "yarn up -R '**' && yarn clean-install",
     "upgrade-packages": "yarn up '*' '@types/node' '@yarnpkg/*' && yarn up -R '**' && yarn clean-install",
+    "upgrade-packages": "yarn up '**' '@types/vscode@={{ cookiecutter.vscode_engine_min_version_tuple }}' && yarn up -R '**' && yarn clean-install",
     "upgrade-yarn-itself": "printf >&2 '%s\\n\\t%s\\n' 'Run the following command line manually:' 'yarn set version stable && yarn install && yarn clean-install' && false",
     "vscode:prepublish": "yarn compile"
   }


### PR DESCRIPTION
- Ensure `yarn upgrade-packages` leaves vscode alone
- Change `engines.vscode` back to a triple
- Suppress unhelpful Git output
