### PR TITLE
VS Code: remove obsolete workarounds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,6 @@
     "**/.venv": true,
     "**/__pycache__": true
   },
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.formatting.provider": "black",
   "python.linting.pylintEnabled": true
 }


### PR DESCRIPTION
Remove workarounds which no longer work with current versions of
VS Code’s Python extension (starting with version 2022.18.1).

From that version on, those workarounds are no longer necessary
anyway. The Python extension now appears to detect the venv’s
interpreter automatically and then switch to it.
