### PR TITLE
Fix regression in post-gen hook

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -6,8 +6,8 @@ shutil.rmtree('licenses')
 
 {%- if cookiecutter.contribute_language == "n" %}
 shutil.rmtree('extension/examples')
-os.remove('extension/share/{{ cookiecutter.first_language_slug }}.tmLanguage.json')
-os.remove('extension/share/language-configuration.json')
+os.remove('extension/share/language/{{ cookiecutter.first_language_slug }}.tmLanguage.json')
+os.remove('extension/share/language/language-configuration.json')
 {%- endif %}
 
 {%- if cookiecutter.dedicated_library_workspace == "n" %}
@@ -18,8 +18,8 @@ git_commands = [
     'git init -q',
     'git add .',
     {%- if cookiecutter.contribute_language == "y" %}
-    'git reset -q extension/examples extension/share/*.json',
-    'git add -N extension/examples extension/share/*.json',
+    'git reset -q extension/examples extension/share/language',
+    'git add -N extension/examples extension/share/language',
     {%- endif %}
     'git reset -q extension/README.md',
     'git add -N extension/README.md',


### PR DESCRIPTION
The recent fix for contributed languages didn’t take into account
pending changes in the post-gen hook. That caused the following error:

> ERROR: Stopping generation because post_gen_project hook script didn't exit successfully

Fix this issue by pointing the post-gen hook to the new file locations.
