### PR TITLE
Migrate to Yarn v4

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -38,8 +38,10 @@ def print_formatted(message: str) -> None:
     print('', width * '-', *message, width * '-', sep='\n')
 
 install_commands = [
-    'yarn set version stable',
-    'yarn plugin import https://mskelton.dev/yarn-outdated/v3',
+    'yarn init -2',
+    'git checkout package.json',
+    'yarn set version 4',
+    'yarn plugin import https://mskelton.dev/yarn-outdated/v4',
     'yarn install',
     'yarn clean-install',
     'git add .yarn .yarnrc.yml package.json yarn.lock',

--- a/{{ cookiecutter.project_slug }}/package.json
+++ b/{{ cookiecutter.project_slug }}/package.json
@@ -6,15 +6,15 @@
   },
   "comments": {
     "devDependencies": {
-      "@yarnpkg/sdks": "Replace the <=2.x || ^3.0.0 restriction with the latest stable version once a stable 3.x release is out."
+      "@yarnpkg/sdks": "Before upgrading to a newer major version, check Node.js version compatibility. When bumping the major version, keep it in sync with `yarn set version` invocations."
     },
     "resolutions": {
-      "@vscode/vsce": "Private patch for Yarn v3 compatibility. Keep in sync with the version of the `@vscode/vsce` dependency."
+      "@vscode/vsce": "Private patch for Yarn v4 compatibility. Keep in sync with the version of the `@vscode/vsce` dependency."
     }
   },
   "devDependencies": {
     "@types/jest": "^29.5.3",
-    "@yarnpkg/sdks": "<=2.x || ^3.0.0",
+    "@yarnpkg/sdks": "<=4.x",
     "typescript": "^5.1.6"
   },
   "resolutions": {
@@ -30,10 +30,10 @@
     {%- if cookiecutter.dedicated_library_workspace == "y" %}
     "test": "yarn workspace {{ cookiecutter.extension_slug }} test",
     {%- endif %}
-    "upgrade-all": "printf >&2 '%s\\n\\t%s\\n' 'Run the following command line manually:' 'yarn set version stable && yarn install && yarn upgrade-packages' && false",
+    "upgrade-all": "printf >&2 '%s\\n\\t%s\\n' 'Run the following command line manually:' 'yarn set version 4 && yarn install && yarn upgrade-packages' && false",
     "upgrade-lockfile": "yarn up -R '**' && yarn clean-install",
-    "upgrade-packages": "yarn up '**' '@types/node@<=18.x' '@types/vscode@={{ cookiecutter.vscode_engine_min_version_tuple }}' '@yarnpkg/sdks@<=2.x || ^3.0.0' && yarn up -R '**' && yarn clean-install",
-    "upgrade-yarn-itself": "printf >&2 '%s\\n\\t%s\\n' 'Run the following command line manually:' 'yarn set version stable && yarn install && yarn clean-install' && false"
+    "upgrade-packages": "yarn up '**' '@types/node@<=18.x' '@types/vscode@={{ cookiecutter.vscode_engine_min_version_tuple }}' '@yarnpkg/sdks@<=4.x' && yarn up -R '**' && yarn clean-install",
+    "upgrade-yarn-itself": "printf >&2 '%s\\n\\t%s\\n' 'Run the following command line manually:' 'yarn set version 4 && yarn install && yarn clean-install' && false"
   },
   "workspaces": [
     "extension"{% if cookiecutter.dedicated_library_workspace == "y" %},


### PR DESCRIPTION
- Bump copyright statement
- Require Node.js 18 or newer
- Migrate to Yarn v4
